### PR TITLE
Refactored code to use local storage to persist userId for current session

### DIFF
--- a/client/src/context/UserAuthContext.jsx
+++ b/client/src/context/UserAuthContext.jsx
@@ -61,6 +61,8 @@ export function UserAuthContextProvider({ children }) {
     })
       .then((res) => {
         console.log('get res', res.data.user_id);
+        //use localstorage to save userId for current session instead of using state(async)
+        window.localStorage.setItem('currentId', res.data.user_id);
         const newUserId = res.data.user_id;
         setUserId(newUserId);
       })

--- a/client/src/itemView/wrapper.jsx
+++ b/client/src/itemView/wrapper.jsx
@@ -54,6 +54,10 @@ const Item = (props) => {
   const { user, userId } = useUserAuth();
   console.log('this should be the user id', userId);
 
+  //new way to get userId (from local storage)
+  const currentId = localStorage.getItem('currentId');
+  console.log('current userId from localstorage', currentId);
+
   useEffect(() => {
     let mounted = true;
     axios.get('/item/itemData', {


### PR DESCRIPTION
@Chloe-Meinshausen introduced an awesome way to persist userId for current session. 
-Instead of waiting for React state to update (async), now we can use localstorage to save and retrieve userId which is much faster 
-In order to get userId in your component, do follow: 
`const currentId = localStorage.getItem('currentId'); 
//you can name your own variable, but do not change 'currentId' on the right side
  console.log('current userId from local-storage', currentId);`
-sample code in @rudyesar 's component itemView/wrapper.jsx (line57-59)
-you could still use the old way to userId , but consider to use local-storage if you can (I kept the code for now, so this change will not break anyone's current component) 

